### PR TITLE
No longer support implicit pydanticize casting of types

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ description = ""
 name = "ab-dependency"
 readme = "README.md"
 requires-python = ">=3.12, <4"
-version = "0.1.9"
+version = "0.2.0"
 
 [project.optional-dependencies]
 fastapi = ["fastapi>= 0.78.0"]

--- a/src/ab_core/dependency/__init__.py
+++ b/src/ab_core/dependency/__init__.py
@@ -1,5 +1,12 @@
 from .depends import Depends, Load
 from .injection import inject
+from .pydanticize import (
+    cached_type_adapter,
+    is_supported_by_pydantic,
+    pydanticize_data,
+    pydanticize_object,
+    pydanticize_type,
+)
 from .sentinel import sentinel
 
 __all__ = [
@@ -7,4 +14,9 @@ __all__ = [
     Load,
     inject,
     sentinel,
+    pydanticize_data,
+    pydanticize_type,
+    pydanticize_object,
+    cached_type_adapter,
+    is_supported_by_pydantic,
 ]

--- a/src/ab_core/dependency/pydanticize/__init__.py
+++ b/src/ab_core/dependency/pydanticize/__init__.py
@@ -4,8 +4,9 @@ from .cast.helpers import cached_type_adapter, is_supported_by_pydantic, pydanti
 from .pydanticize import pydanticize_data
 
 __all__ = [
-    "pydanticize_datapydanticize_type",
-    "pydanticize_object",
-    "cached_type_adapter",
-    "is_supported_by_pydantic",
+    pydanticize_data,
+    pydanticize_type,
+    pydanticize_object,
+    cached_type_adapter,
+    is_supported_by_pydantic,
 ]

--- a/src/ab_core/dependency/pydanticize/cast/adaptors/unset.py
+++ b/src/ab_core/dependency/pydanticize/cast/adaptors/unset.py
@@ -37,7 +37,8 @@ class UnsetStripPlugin(BaseTypePlugin):
           Union[Unset]             -> Any   (degenerate case)
 
         """
-        from ab_core.dependency.pydanticize.cast.helpers import PLUGINS, pydanticize_type
+        from ab_core.dependency.pydanticize.cast.helpers import pydanticize_type
+
         args = tuple(a for a in get_args(_type) if not _is_unset(a))
         if not args:
             cleaned: Any = Any  # Degenerate: Union[Unset] -> Any

--- a/src/ab_core/dependency/pydanticize/cast/helpers.py
+++ b/src/ab_core/dependency/pydanticize/cast/helpers.py
@@ -8,8 +8,8 @@ from typing import ParamSpec, TypeVar, cast
 from pydantic import TypeAdapter
 
 from .adaptors.attrs import HAS_ATTRS, AttrsPlugin
-from .adaptors.unset import UnsetStripPlugin
 from .adaptors.base import BaseTypePlugin
+from .adaptors.unset import UnsetStripPlugin
 
 # ---------- typed cache wrapper ----------
 P = ParamSpec("P")

--- a/src/ab_core/dependency/schema/__init__.py
+++ b/src/ab_core/dependency/schema/__init__.py
@@ -1,0 +1,7 @@
+"""Schema module for dependency management."""
+
+from .loader_type import LoaderSource
+
+__all__ = [
+    LoaderSource,
+]

--- a/tests/ab_core/dependency/test_depends.py
+++ b/tests/ab_core/dependency/test_depends.py
@@ -83,11 +83,11 @@ LOAD_TARGETS = [
     # discriminated union of attrs classes
     FooBarAttrs,
     # attrs classes themselves
-    FooAttrs,
-    BarAttrs,
+    pydanticize_type(FooAttrs),
+    pydanticize_type(BarAttrs),
     # environment loaders targeting attrs classes
-    ObjectLoaderEnvironment[FooAttrs](),
-    ObjectLoaderEnvironment[BarAttrs](),
+    ObjectLoaderEnvironment[pydanticize_type(FooAttrs)](),
+    ObjectLoaderEnvironment[pydanticize_type(BarAttrs)](),
     foo,
     bar,
     FooClass,


### PR DESCRIPTION
Due to a change in the way the generic-preserver handles pydantic models, this package no longer allows implicit casting of non pydantic types into pydantic types. Use of this module now eximplicitly requires you to call `pydanticize_type(SOME_TYPE)` before passing it into the Depends / Objectloader etc.