### PR TITLE
feat: support python 3.12 PEP 695 `type` syntax

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ description = ""
 name = "pydantic-di"
 readme = "README.md"
 requires-python = ">=3.12, <4"
-version = "0.2.3"
+version = "0.2.4"
 
 [project.optional-dependencies]
 fastapi = ["fastapi>= 0.78.0"]

--- a/src/pydantic_di/utils.py
+++ b/src/pydantic_di/utils.py
@@ -5,7 +5,7 @@ import os
 import re
 from collections.abc import Iterator
 from copy import deepcopy
-from typing import get_args
+from typing import TypeAliasType, get_args
 
 
 def str_intersection(*args: str) -> str:
@@ -116,21 +116,29 @@ def deep_merge(
     return merged
 
 
-def walk_types_args(t_base: type):
+def walk_types_args(t_base: object):
     """Yield a type and every nested argument type recursively."""
+    seen: set[int] = set()
 
     def walk(t):
+        identity = id(t)
+        if identity in seen:
+            return
+
+        seen.add(identity)
         yield t
 
-        t_args = get_args(t)
+        if isinstance(t, TypeAliasType):
+            yield from walk(t.__value__)
+            return
 
-        for t_arg in t_args:
+        for t_arg in get_args(t):
             yield from walk(t_arg)
 
     yield from walk(t_base)
 
 
-def extract_target_types(obj: type, target_type: type) -> Iterator[type | object]:
+def extract_target_types(obj: object, target_type: type) -> Iterator[type | object]:
     """Yield nested types that match or subclass `target_type`."""
     for t in walk_types_args(obj):
         if isinstance(t, target_type) or isinstance(t, type) and issubclass(t, target_type):

--- a/tests/pydantic_di/loaders/test_environment_object.py
+++ b/tests/pydantic_di/loaders/test_environment_object.py
@@ -77,6 +77,33 @@ def test_loader_single_type(env_overrides, expected_values, expected_instance):
         assert result == expected_instance
 
 
+def test_loader_supports_legacy_type_alias():
+    loader = ObjectLoaderEnvironment[LoaderUnion](
+        default_discriminator_value="A",
+    )
+
+    with patch.dict(os.environ, {}, clear=True):
+        result = loader.load()
+
+    assert result == DummyStoreA()
+
+
+def test_loader_supports_pep695_type_alias():
+    type RoleStore = Annotated[
+        DummyStoreA | DummyStoreB,
+        Discriminator("type"),
+    ]
+
+    loader = ObjectLoaderEnvironment[RoleStore](
+        default_discriminator_value="A",
+    )
+
+    with patch.dict(os.environ, {}, clear=True):
+        result = loader.load()
+
+    assert result == DummyStoreA()
+
+
 class Credentials(BaseModel):
     username: str
     password: str

--- a/tests/pydantic_di/test_utils.py
+++ b/tests/pydantic_di/test_utils.py
@@ -1,7 +1,9 @@
-import pytest
-from pydantic import BaseModel
+from typing import Annotated
 
-from pydantic_di.utils import deep_merge, to_env_prefix, type_name_intersection
+import pytest
+from pydantic import BaseModel, Discriminator
+
+from pydantic_di.utils import deep_merge, extract_target_types, to_env_prefix, type_name_intersection
 
 
 class DummyStoreA(BaseModel): ...
@@ -132,3 +134,29 @@ def test_deep_merge_non_dict_configured_replaces_dict_default():
     assert merged == {
         "service": "disabled",
     }
+
+
+def test_extract_target_types_unwraps_pep695_type_alias():
+    type RoleStore = Annotated[
+        DummyStoreA | DummyStoreB,
+        Discriminator("type"),
+    ]
+
+    models = list(extract_target_types(RoleStore, BaseModel))
+    discriminator = list(extract_target_types(RoleStore, Discriminator))
+
+    assert models == [DummyStoreA, DummyStoreB]
+    assert len(discriminator) == 1
+    assert discriminator[0].discriminator == "type"
+
+
+def test_extract_target_types_recursively_unwraps_pep695_aliases():
+    type RoleStoreModels = DummyStoreA | DummyStoreB
+    type RoleStore = Annotated[
+        RoleStoreModels,
+        Discriminator("type"),
+    ]
+
+    models = list(extract_target_types(RoleStore, BaseModel))
+
+    assert models == [DummyStoreA, DummyStoreB]


### PR DESCRIPTION
Implemented the PEP 695 alias fix and bumped the patch version.

Changed [utils.py](/Users/s129710/Documents/Github/mattcoulter7/pydantic-di/src/pydantic_di/utils.py:119) so `walk_types_args()` unwraps `typing.TypeAliasType.__value__` recursively, with `seen` protection for recursive/pathological aliases. `extract_target_types()` now accepts `object` as input since aliases are not plain `type` objects.

Added regression coverage in [test_utils.py](/Users/s129710/Documents/Github/mattcoulter7/pydantic-di/tests/pydantic_di/test_utils.py:139) for direct PEP 695 alias extraction and nested aliases, plus loader coverage in [test_environment_object.py](/Users/s129710/Documents/Github/mattcoulter7/pydantic-di/tests/pydantic_di/loaders/test_environment_object.py:80) for both legacy and PEP 695 alias syntax.

Bumped package version in [pyproject.toml](/Users/s129710/Documents/Github/mattcoulter7/pydantic-di/pyproject.toml:29) from `0.2.3` to `0.2.4`.

Verification:
`ruff check ...` passed.
`uv run pytest -v -m "not integration"` passed: 143 passed, 1 skipped.